### PR TITLE
SPTextUtil.harSPINRDF() to allow non-SPIN properties on Commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.topbraid</groupId>
-	<artifactId>spin</artifactId>
+	<groupId>org.spinrdf</groupId>
+	<artifactId>core</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.0</version>
-	<name>TopBraid SPIN API</name>
+	<version>3.0.0-SNAPSHOT</version>
+	<name>SPIN API</name>
 	<url>http://spinrdf.org/</url>
 
 	<description>

--- a/src/main/java/org/spinrdf/util/SPTextUtil.java
+++ b/src/main/java/org/spinrdf/util/SPTextUtil.java
@@ -178,7 +178,7 @@ public class SPTextUtil {
 		try {
 			while(it.hasNext()) {
 				Statement o = it.next();
-				if(!RDF.type.equals(o.getPredicate()) && !SP.text.equals(o.getPredicate()) && !SPIN.thisUnbound.equals(o.getPredicate())) {
+				if (SP.NS.equals(o.getPredicate().getNameSpace()) && !SP.text.equals(o.getPredicate())) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Fix #2: SPTextUtil.harSPINRDF() to allow non-SPIN properties on Commands

This method should probably move to `Command.hasSPINRDF()` eventually