### PR TITLE
SPTextUtil.harSPINRDF() to allow non-SPIN properties on Commands

### DIFF
--- a/src/main/java/org/spinrdf/util/SPTextUtil.java
+++ b/src/main/java/org/spinrdf/util/SPTextUtil.java
@@ -178,7 +178,7 @@ public class SPTextUtil {
 		try {
 			while(it.hasNext()) {
 				Statement o = it.next();
-				if(!RDF.type.equals(o.getPredicate()) && !SP.text.equals(o.getPredicate()) && !SPIN.thisUnbound.equals(o.getPredicate())) {
+				if (SP.NS.equals(o.getPredicate().getNameSpace()) && !SP.text.equals(o.getPredicate())) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Fixes #2 
This method should probably move to `Command.hasSPINRDF()` eventually