### PR TITLE
Updated Maven artifact to org.spinrdf:core:3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.topbraid</groupId>
-	<artifactId>spin</artifactId>
+	<groupId>org.spinrdf</groupId>
+	<artifactId>core</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.0</version>
-	<name>TopBraid SPIN API</name>
+	<version>3.0.0-SNAPSHOT</version>
+	<name>SPIN RDF API</name>
 	<url>http://spinrdf.org/</url>
 
 	<description>


### PR DESCRIPTION
The new Maven config goes like this:

	<groupId>org.spinrdf</groupId>
	<artifactId>core</artifactId>
	<packaging>jar</packaging>
	<version>3.0.0-SNAPSHOT</version>
	<name>SPIN RDF API</name>
	<url>http://spinrdf.org/</url>

Not sure about the `artifactId`, feel free to suggest a better one.