### PR TITLE
Support negated property paths (resolves issue #14)

### DIFF
--- a/etc/sp.ttl
+++ b/etc/sp.ttl
@@ -263,6 +263,12 @@ sp:ReversePath
   rdfs:label "Reverse path"^^xsd:string ;
   rdfs:subClassOf sp:Path ;
 .
+sp:ReversePath
+  rdf:type rdfs:Class ;
+  rdfs:comment "A negated property path." ;
+  rdfs:label "Negated path"^^xsd:string ;
+  rdfs:subClassOf sp:Path ;
+.
 sp:Sample
   rdf:type rdfs:Class ;
   rdfs:comment "Represents SAMPLE aggregations"^^xsd:string ;

--- a/etc/sp.ttl
+++ b/etc/sp.ttl
@@ -263,7 +263,7 @@ sp:ReversePath
   rdfs:label "Reverse path"^^xsd:string ;
   rdfs:subClassOf sp:Path ;
 .
-sp:ReversePath
+sp:NegatedPath
   rdf:type rdfs:Class ;
   rdfs:comment "A negated property path." ;
   rdfs:label "Negated path"^^xsd:string ;

--- a/src/main/java/org/spinrdf/arq/ARQ2SPIN.java
+++ b/src/main/java/org/spinrdf/arq/ARQ2SPIN.java
@@ -65,8 +65,10 @@ import org.apache.jena.sparql.path.P_FixedLength;
 import org.apache.jena.sparql.path.P_Inverse;
 import org.apache.jena.sparql.path.P_Link;
 import org.apache.jena.sparql.path.P_Mod;
+import org.apache.jena.sparql.path.P_NegPropSet;
 import org.apache.jena.sparql.path.P_OneOrMore1;
 import org.apache.jena.sparql.path.P_OneOrMoreN;
+import org.apache.jena.sparql.path.P_Path0;
 import org.apache.jena.sparql.path.P_Path1;
 import org.apache.jena.sparql.path.P_ReverseLink;
 import org.apache.jena.sparql.path.P_Seq;
@@ -778,6 +780,12 @@ public class ARQ2SPIN {
 			P_ReverseLink rl = (P_ReverseLink) path;
 			Resource r = model.createResource(SP.ReverseLinkPath);
 			r.addProperty(SP.node, model.asRDFNode(rl.getNode()));
+			return r;
+		} else if(path instanceof P_NegPropSet) {
+			P_NegPropSet neg = (P_NegPropSet) path;
+			List<P_Path0> p = neg.getNodes();
+			Resource r = model.createResource(SP.NegatedPath);
+			r.addProperty(SP.node, createPath(p.get(0)));
 			return r;
 		}
 		else {

--- a/src/main/java/org/spinrdf/model/impl/TriplePathImpl.java
+++ b/src/main/java/org/spinrdf/model/impl/TriplePathImpl.java
@@ -28,6 +28,7 @@ import org.apache.jena.sparql.path.P_Alt;
 import org.apache.jena.sparql.path.P_Inverse;
 import org.apache.jena.sparql.path.P_Link;
 import org.apache.jena.sparql.path.P_Mod;
+import org.apache.jena.sparql.path.P_NegPropSet;
 import org.apache.jena.sparql.path.P_OneOrMore1;
 import org.apache.jena.sparql.path.P_ReverseLink;
 import org.apache.jena.sparql.path.P_Seq;
@@ -131,7 +132,13 @@ public class TriplePathImpl extends TupleImpl implements TriplePath {
 				else if(SP.ReverseLinkPath.equals(type)) {
 					Node node = JenaUtil.getProperty(path, SP.node).asNode();
 					return new P_ReverseLink(node);
+				} else if(SP.NegatedPath.equals(type)) {
+					Node node = JenaUtil.getProperty(path, SP.node).asNode();
+					P_NegPropSet p = new P_NegPropSet();
+					p.add(new P_Link(node));
+					return p;
 				}
+
 			}
 			return null;
 		}

--- a/src/main/java/org/spinrdf/vocabulary/SP.java
+++ b/src/main/java/org/spinrdf/vocabulary/SP.java
@@ -132,6 +132,8 @@ public class SP {
 
     public final static Resource ReversePath = ResourceFactory.createResource(NS + "ReversePath");
 
+    public final static Resource NegatedPath = ResourceFactory.createResource(NS + "NegatedPath");
+    
     public final static Resource Select = ResourceFactory.createResource(NS + "Select");
 
     public final static Resource Service = ResourceFactory.createResource(NS + "Service");

--- a/src/test/java/org/topbraid/spin/NegatedPropertyPath.java
+++ b/src/test/java/org/topbraid/spin/NegatedPropertyPath.java
@@ -1,0 +1,61 @@
+package org.topbraid.spin;
+
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Model;
+import org.spinrdf.arq.ARQ2SPIN;
+import org.spinrdf.arq.ARQFactory;
+import org.spinrdf.model.Select;
+import org.spinrdf.model.Template;
+import org.spinrdf.system.SPINModuleRegistry;
+import org.spinrdf.util.JenaUtil;
+import org.spinrdf.util.SystemTriples;
+import org.spinrdf.vocabulary.SP;
+import org.spinrdf.vocabulary.SPIN;
+
+/**
+ * Creates a SPIN template containing a negated property paht and "calls" it.
+ * 
+ * @author Robin Keskisärkkä
+ */
+public class NegatedPropertyPath {
+
+	// Query of the template - argument will be arg:predicate
+	private static final String QUERY = ""
+			+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> "
+			+ "PREFIX owl:  <http://www.w3.org/2002/07/owl#> "
+			+ "SELECT * "
+			+ "WHERE { "
+			+ "   owl:Restriction !rdfs:label ?o . "
+			+ "}";
+
+	public static void main(String[] args) {
+		SPINModuleRegistry.get().init();
+
+		Model model = JenaUtil.createDefaultModel();
+		model.setNsPrefix("sp", SP.getURI());
+		model.setNsPrefix("spin", SPIN.NS);
+		Template template = createTemplate(model);
+		model.write(System.out, "TTL");
+
+		// Query the system triples
+		model.add(SystemTriples.getVocabularyModel());
+		org.apache.jena.query.Query arq = ARQFactory.get().createQuery((Select) template.getBody());
+		QueryExecution qexec = ARQFactory.get().createQueryExecution(arq, model);
+		ResultSet rs = qexec.execSelect();
+		while(rs.hasNext()){
+			System.out.println(rs.next());
+		}
+		
+		
+	}
+
+	private static Template createTemplate(Model model) {
+		Query arqQuery = ARQFactory.get().createQuery(model, QUERY);
+		org.spinrdf.model.Query spinQuery = new ARQ2SPIN(model).createQuery(arqQuery, null);
+		Template template = model.createResource(null, SPIN.Template).as(Template.class);
+		template.addProperty(SPIN.body, spinQuery);
+		return template;
+	}
+}


### PR DESCRIPTION
Resolves issue #14.

Changes proposed are:
- Add negated property class to SPIN SPARQL Syntax (`sp:NegatedPath` added to `sp.ttl`)
- Add support for in negated path in API. Leverages constructs already present in ARQ.
- Add `src/test`.