### PR TITLE
Improved Template and TemplateCall retrieval

### DIFF
--- a/src/main/java/org/spinrdf/model/SPINFactory.java
+++ b/src/main/java/org/spinrdf/model/SPINFactory.java
@@ -261,13 +261,21 @@ public class SPINFactory {
 	 */
 	public static TemplateCall asTemplateCall(RDFNode node) {
 		if(node instanceof Resource) {
-			Statement s = ((Resource)node).getProperty(RDF.type);
-			if(s != null && s.getObject().isURIResource()) {
-				String uri = s.getResource().getURI();
-				Template template = SPINModuleRegistry.get().getTemplate(uri, s.getModel());
-				if(template != null) {
-					return node.as(TemplateCall.class);
+			StmtIterator it = ((Resource)node).listProperties(RDF.type);
+			try {
+				while (it.hasNext()) {
+					Statement s = it.next();
+					if(s != null && s.getObject().isURIResource()) {
+						String uri = s.getResource().getURI();
+						Template template = SPINModuleRegistry.get().getTemplate(uri, s.getModel());
+						if(template != null) {
+							return node.as(TemplateCall.class);
+						}
+					}
 				}
+			}
+			finally {
+				it.close();
 			}
 		}
 		return null;

--- a/src/main/java/org/spinrdf/model/impl/TemplateCallImpl.java
+++ b/src/main/java/org/spinrdf/model/impl/TemplateCallImpl.java
@@ -29,6 +29,7 @@ import org.apache.jena.query.QuerySolutionMap;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
 import org.spinrdf.arq.ARQFactory;
 import org.spinrdf.model.*;
@@ -149,13 +150,24 @@ public class TemplateCallImpl extends ModuleCallImpl implements TemplateCall {
 
 
 	public Template getTemplate() {
-		Statement s = getProperty(RDF.type);
-		if(s != null && s.getObject().isURIResource()) {
-			return SPINModuleRegistry.get().getTemplate(s.getResource().getURI(), getModel());
+		StmtIterator it = listProperties(RDF.type);
+		try
+		{
+			while (it.hasNext()) {
+				Statement s = it.next();
+				if(s != null && s.getObject().isURIResource()) {
+					String uri = s.getResource().getURI();
+					Template template = SPINModuleRegistry.get().getTemplate(uri, getModel());
+					if(template != null) {
+						return template;
+					}
+				}
+			}
 		}
-		else {
-			return null;
+		finally {
+			it.close();
 		}
+		return null;
 	}
 
 


### PR DESCRIPTION
Iterate `RDF.type`s instead of getting the first one. In general a `Template`/`TemplateCall` resource can have more than one type (e.g. as a result of inference).

Not sure if the iterator needs to be closed explicitly, I can remove that part if it's unnecessary.